### PR TITLE
Add `.git` to `.distignore`

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,3 +1,4 @@
+/.git
 /.github
 /.gitattributes
 /.gitignore


### PR DESCRIPTION
This ensures our releases to WPORG don't include the git directory, see: https://github.com/10up/action-wordpress-plugin-deploy?tab=readme-ov-file#excluding-files-from-deployment