### PR TITLE
Add support for aspect ratios with Gemini (multimodal) image generation

### DIFF
--- a/src/Metadata/GoogleModelMetadataDirectory.php
+++ b/src/Metadata/GoogleModelMetadataDirectory.php
@@ -138,6 +138,13 @@ class GoogleModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
             new SupportedOption(OptionEnum::webSearch()),
         ]);
         $geminiMultimodalImageOutputOptions = array_merge($geminiBaseOptions, [
+            new SupportedOption(OptionEnum::outputFileType(), [FileTypeEnum::inline()]),
+            new SupportedOption(OptionEnum::outputMediaOrientation(), [
+                MediaOrientationEnum::square(),
+                MediaOrientationEnum::landscape(),
+                MediaOrientationEnum::portrait(),
+            ]),
+            new SupportedOption(OptionEnum::outputMediaAspectRatio(), ['1:1', '16:9', '4:3', '9:16', '3:4']),
             new SupportedOption(
                 OptionEnum::inputModalities(),
                 $allModalityCombinationsWithText

--- a/src/Metadata/GoogleModelMetadataDirectory.php
+++ b/src/Metadata/GoogleModelMetadataDirectory.php
@@ -103,6 +103,12 @@ class GoogleModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
             [ModalityEnum::text(), ModalityEnum::image(), ModalityEnum::audio(), ModalityEnum::document()],
         ];
 
+        $geminiImageAspectRatios = ['1:1', '16:9', '4:3', '3:2', '5:4', '9:16', '3:4', '2:3', '4:5', '21:9'];
+        $gemini31ImageAspectRatios = array_merge(
+            $geminiImageAspectRatios,
+            ['4:1', '8:1', '1:4', '1:8']
+        );
+
         $geminiCapabilities = [
             CapabilityEnum::textGeneration(),
             CapabilityEnum::chatHistory(),
@@ -144,7 +150,7 @@ class GoogleModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                 MediaOrientationEnum::landscape(),
                 MediaOrientationEnum::portrait(),
             ]),
-            new SupportedOption(OptionEnum::outputMediaAspectRatio(), ['1:1', '16:9', '4:3', '9:16', '3:4']),
+            new SupportedOption(OptionEnum::outputMediaAspectRatio(), $geminiImageAspectRatios),
             new SupportedOption(
                 OptionEnum::inputModalities(),
                 $allModalityCombinationsWithText
@@ -172,7 +178,7 @@ class GoogleModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                 MediaOrientationEnum::landscape(),
                 MediaOrientationEnum::portrait(),
             ]),
-            new SupportedOption(OptionEnum::outputMediaAspectRatio(), ['1:1', '16:9', '4:3', '9:16', '3:4']),
+            new SupportedOption(OptionEnum::outputMediaAspectRatio(), $geminiImageAspectRatios),
             new SupportedOption(OptionEnum::customOptions()),
         ];
 
@@ -186,7 +192,8 @@ class GoogleModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                     $geminiOptions,
                     $geminiMultimodalImageOutputOptions,
                     $imagenCapabilities,
-                    $imagenOptions
+                    $imagenOptions,
+                    $gemini31ImageAspectRatios
                 ): ModelMetadata {
                     $modelId = $modelData['baseModelId'] ?? $modelData['name'];
                     if (str_starts_with($modelId, 'models/')) {
@@ -207,6 +214,20 @@ class GoogleModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                         ) {
                             $modelCaps = $geminiMultimodalImageOutputCapabilities;
                             $modelOptions = $geminiMultimodalImageOutputOptions;
+                            if (str_starts_with($modelId, 'gemini-3.1')) {
+                                $modelOptions = array_map(
+                                    static function (SupportedOption $option) use ($gemini31ImageAspectRatios) {
+                                        if ($option->getName()->isOutputMediaAspectRatio()) {
+                                            return new SupportedOption(
+                                                $option->getName(),
+                                                $gemini31ImageAspectRatios
+                                            );
+                                        }
+                                        return $option;
+                                    },
+                                    $modelOptions
+                                );
+                            }
                         } else {
                             $modelOptions = $geminiOptions;
                         }

--- a/src/Models/GoogleImageGenerationModel.php
+++ b/src/Models/GoogleImageGenerationModel.php
@@ -7,7 +7,6 @@ namespace WordPress\GoogleAiProvider\Models;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Files\DTO\File;
-use WordPress\AiClient\Files\Enums\MediaOrientationEnum;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
@@ -53,6 +52,8 @@ use WordPress\GoogleAiProvider\Provider\GoogleProvider;
  */
 class GoogleImageGenerationModel extends AbstractApiBasedModel implements ImageGenerationModelInterface
 {
+    use WithAspectRatioTrait;
+
     /**
      * {@inheritDoc}
      *
@@ -203,34 +204,6 @@ class GoogleImageGenerationModel extends AbstractApiBasedModel implements ImageG
         }
 
         return $text;
-    }
-
-    /**
-     * Prepares the aspect ratio parameter for the API request.
-     *
-     * @since 1.0.0
-     *
-     * @param MediaOrientationEnum|null $orientation The desired media orientation.
-     * @param string|null $aspectRatio The desired media aspect ratio.
-     * @return string The prepared aspect ratio parameter.
-     */
-    protected function prepareAspectRatioParam(?MediaOrientationEnum $orientation, ?string $aspectRatio): string
-    {
-        // Use aspect ratio if set, as it is more specific.
-        if ($aspectRatio !== null) {
-            return $aspectRatio;
-        }
-
-        // This should always have a value, as the method is only called if at least one or the other is set.
-        if ($orientation !== null) {
-            if ($orientation->isLandscape()) {
-                return '16:9';
-            }
-            if ($orientation->isPortrait()) {
-                return '9:16';
-            }
-        }
-        return '1:1';
     }
 
     /**

--- a/src/Models/GoogleTextGenerationModel.php
+++ b/src/Models/GoogleTextGenerationModel.php
@@ -56,6 +56,8 @@ use WordPress\GoogleAiProvider\Provider\GoogleProvider;
  */
 class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGenerationModelInterface
 {
+    use WithAspectRatioTrait;
+
     /**
      * {@inheritDoc}
      *
@@ -129,6 +131,18 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
         $outputModalities = $config->getOutputModalities();
         if (is_array($outputModalities)) {
             $generationConfig['responseModalities'] = $this->prepareResponseModalitiesParam($outputModalities);
+            if (in_array('Image', $generationConfig['responseModalities'], true)) {
+                $outputMediaOrientation = $config->getOutputMediaOrientation();
+                $outputMediaAspectRatio = $config->getOutputMediaAspectRatio();
+                if ($outputMediaOrientation !== null || $outputMediaAspectRatio !== null) {
+                    $generationConfig['imageConfig'] = [
+                        'aspectRatio' => $this->prepareAspectRatioParam(
+                            $outputMediaOrientation,
+                            $outputMediaAspectRatio
+                        ),
+                    ];
+                }
+            }
         }
 
         $candidateCount = $config->getCandidateCount();

--- a/src/Models/WithAspectRatioTrait.php
+++ b/src/Models/WithAspectRatioTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\GoogleAiProvider\Models;
+
+use WordPress\AiClient\Files\Enums\MediaOrientationEnum;
+
+/**
+ * Trait for handling aspect ratio preparation.
+ *
+ * @since 1.0.0
+ */
+trait WithAspectRatioTrait
+{
+    /**
+     * Prepares the aspect ratio parameter for the API request.
+     *
+     * @since 1.0.0
+     *
+     * @param MediaOrientationEnum|null $orientation The desired media orientation.
+     * @param string|null $aspectRatio The desired media aspect ratio.
+     * @return string The prepared aspect ratio parameter.
+     */
+    protected function prepareAspectRatioParam(?MediaOrientationEnum $orientation, ?string $aspectRatio): string
+    {
+        // Use aspect ratio if set, as it is more specific.
+        if ($aspectRatio !== null) {
+            return $aspectRatio;
+        }
+
+        // This should always have a value, as the method is only called if at least one or the other is set.
+        if ($orientation !== null) {
+            if ($orientation->isLandscape()) {
+                return '16:9';
+            }
+            if ($orientation->isPortrait()) {
+                return '9:16';
+            }
+        }
+        return '1:1';
+    }
+}

--- a/src/Models/WithAspectRatioTrait.php
+++ b/src/Models/WithAspectRatioTrait.php
@@ -9,14 +9,14 @@ use WordPress\AiClient\Files\Enums\MediaOrientationEnum;
 /**
  * Trait for handling aspect ratio preparation.
  *
- * @since 1.0.0
+ * @since n.e.x.t
  */
 trait WithAspectRatioTrait
 {
     /**
      * Prepares the aspect ratio parameter for the API request.
      *
-     * @since 1.0.0
+     * @since n.e.x.t
      *
      * @param MediaOrientationEnum|null $orientation The desired media orientation.
      * @param string|null $aspectRatio The desired media aspect ratio.


### PR DESCRIPTION
* Gemini image models (technically multimodal) support various aspect ratios that can be specified, but this was not supported so far.
* The list of aspect ratios has also been updated, as they support many more than Imagen. For reference, see https://ai.google.dev/gemini-api/docs/image-generation#aspect_ratios_and_image_size

This also addresses a follow up concern from #10 (explicitly supporting "inline" file type for these models).

cc @dkotter