### PR TITLE
Fix text and image multimodal support so that it properly works regardless of capability chosen

### DIFF
--- a/src/Models/GoogleImageGenerationModel.php
+++ b/src/Models/GoogleImageGenerationModel.php
@@ -78,12 +78,17 @@ class GoogleImageGenerationModel extends AbstractApiBasedModel implements ImageG
      */
     public function generateImageResult(array $prompt): GenerativeAiResult
     {
-        /*
-         * Gemini models that can generate images are multimodal and therefore
-         * go through the more flexible `generateContent` endpoint, which is
-         * used by the `GoogleTextGenerationModel` class.
-         */
+        // TODO: Remove this workaround soon - here just for backward compatibility when
+        // GoogleTextAndImageGenerationModel did not exist.
         if (str_starts_with($this->metadata()->getId(), 'gemini-')) {
+            _doing_it_wrong(
+                __METHOD__,
+                sprintf(
+                    'Gemini image models should be used via %s going forward.',
+                    GoogleTextAndImageGenerationModel::class
+                ),
+                'n.e.x.t'
+            );
             $multimodalOutputModel = new GoogleTextGenerationModel($this->metadata(), $this->providerMetadata());
             $multimodalOutputModel->setConfig($this->getConfig());
             $multimodalOutputModel->setHttpTransporter($this->getHttpTransporter());

--- a/src/Models/GoogleTextAndImageGenerationModel.php
+++ b/src/Models/GoogleTextAndImageGenerationModel.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\GoogleAiProvider\Models;
+
+use WordPress\AiClient\Providers\ApiBasedImplementation\Contracts\ApiBasedModelInterface;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
+use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
+use WordPress\AiClient\Providers\Http\Contracts\WithHttpTransporterInterface;
+use WordPress\AiClient\Providers\Http\Contracts\WithRequestAuthenticationInterface;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\ImageGeneration\Contracts\ImageGenerationModelInterface;
+use WordPress\AiClient\Providers\Models\TextGeneration\Contracts\TextGenerationModelInterface;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+
+/**
+ * Class for a Google model that supports both text and image generation.
+ *
+ * This is a pure composition wrapper around GoogleTextGenerationModel. Both text and image generation
+ * delegate to the language-model endpoint — the framework sets the image output modality on the config
+ * before calling generateImageResult().
+ *
+ * @since n.e.x.t
+ */
+class GoogleTextAndImageGenerationModel implements
+    ApiBasedModelInterface,
+    WithHttpTransporterInterface,
+    WithRequestAuthenticationInterface,
+    TextGenerationModelInterface,
+    ImageGenerationModelInterface
+{
+    /**
+     * @var GoogleTextGenerationModel The inner text generation model.
+     */
+    private GoogleTextGenerationModel $model;
+
+    /**
+     * Constructor.
+     *
+     * @since n.e.x.t
+     *
+     * @param ModelMetadata    $metadata         The metadata for the model.
+     * @param ProviderMetadata $providerMetadata The metadata for the model's provider.
+     */
+    public function __construct(ModelMetadata $metadata, ProviderMetadata $providerMetadata) {
+        $this->model = new GoogleTextGenerationModel($metadata, $providerMetadata);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function metadata(): ModelMetadata
+    {
+        return $this->model->metadata();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function providerMetadata(): ProviderMetadata
+    {
+        return $this->model->providerMetadata();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function setConfig(ModelConfig $config): void
+    {
+        $this->model->setConfig($config);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function getConfig(): ModelConfig
+    {
+        return $this->model->getConfig();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function setRequestOptions(RequestOptions $requestOptions): void
+    {
+        $this->model->setRequestOptions($requestOptions);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function getRequestOptions(): ?RequestOptions
+    {
+        return $this->model->getRequestOptions();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function setHttpTransporter(HttpTransporterInterface $httpTransporter): void
+    {
+        $this->model->setHttpTransporter($httpTransporter);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function getHttpTransporter(): HttpTransporterInterface
+    {
+        return $this->model->getHttpTransporter();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function setRequestAuthentication(RequestAuthenticationInterface $requestAuthentication): void
+    {
+        $this->model->setRequestAuthentication($requestAuthentication);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function getRequestAuthentication(): RequestAuthenticationInterface
+    {
+        return $this->model->getRequestAuthentication();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function generateTextResult(array $prompt): GenerativeAiResult
+    {
+        return $this->model->generateTextResult($prompt);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function generateImageResult(array $prompt): GenerativeAiResult
+    {
+        return $this->model->generateTextResult($prompt);
+    }
+}

--- a/src/Provider/GoogleProvider.php
+++ b/src/Provider/GoogleProvider.php
@@ -17,6 +17,7 @@ use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\GoogleAiProvider\Metadata\GoogleModelMetadataDirectory;
 use WordPress\GoogleAiProvider\Models\GoogleImageGenerationModel;
+use WordPress\GoogleAiProvider\Models\GoogleTextAndImageGenerationModel;
 use WordPress\GoogleAiProvider\Models\GoogleTextGenerationModel;
 
 /**
@@ -45,16 +46,13 @@ class GoogleProvider extends AbstractApiProvider
         ModelMetadata $modelMetadata,
         ProviderMetadata $providerMetadata
     ): ModelInterface {
-        /*
-         * Temporary workaround: We don't have a clean way of returning multimodal output model classes yet,
-         * currently the implementations are separated by capability. There are a few Google models that support both
-         * text and image generation, so if we detect that the model supports image generation, we'll return the image
-         * generation model class in that case, because it's far more likely that users want to use those models for
-         * image generation. We will have to revisit that in the near future for a proper solution.
-         */
+        // For multimodal text and image models, return the composition wrapper that implements both capabilities.
         $capabilitiesStringList = $modelMetadata->toArray()[ModelMetadata::KEY_SUPPORTED_CAPABILITIES];
-        if (in_array('image_generation', $capabilitiesStringList, true)) {
-            return new GoogleImageGenerationModel($modelMetadata, $providerMetadata);
+        if (
+            in_array('text_generation', $capabilitiesStringList, true) &&
+            in_array('image_generation', $capabilitiesStringList, true)
+        ) {
+            return new GoogleTextAndImageGenerationModel($modelMetadata, $providerMetadata);
         }
 
         $capabilities = $modelMetadata->getSupportedCapabilities();


### PR DESCRIPTION
So far, the Gemini multimodal text and image models were only working when used for the `image_generation` capability, even though they technically support both `text_generation` and `image_generation`.

They always were able to create both in our implementation, but the routing (model metadata plus class interfaces implemented) was not quite right.

This PR fixes the last important bit, by introducing a class that implements both the `generateTextResult` and `generateImageResult` methods.

cc @dkotter