### PR TITLE
Remove `additionalProperties` from the JSON response schema

### DIFF
--- a/src/Models/GoogleTextGenerationModel.php
+++ b/src/Models/GoogleTextGenerationModel.php
@@ -520,6 +520,20 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
                 $schema['properties'][$key] = $this->removeAdditionalPropertiesKey($childSchema);
             }
         }
+        if (isset($schema['items']) && is_array($schema['items'])) {
+            if (array_is_list($schema['items'])) {
+                foreach ($schema['items'] as $key => $itemSchema) {
+                    if (is_array($itemSchema)) {
+                        /** @var array<string, mixed> $itemSchema */
+                        $schema['items'][$key] = $this->removeAdditionalPropertiesKey($itemSchema);
+                    }
+                }
+            } else {
+                /** @var array<string, mixed> $items */
+                $items = $schema['items'];
+                $schema['items'] = $this->removeAdditionalPropertiesKey($items);
+            }
+        }
         return $schema;
     }
 

--- a/src/Models/GoogleTextGenerationModel.php
+++ b/src/Models/GoogleTextGenerationModel.php
@@ -201,7 +201,8 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
             if ($outputMimeType === 'application/json') {
                 $outputSchema = $config->getOutputSchema();
                 if ($outputSchema) {
-                    $generationConfig['responseSchema'] = $outputSchema;
+                    // The Google AI API does not allow the `additionalProperties` key for response schemas.
+                    $generationConfig['responseSchema'] = $this->removeAdditionalPropertiesKey($outputSchema);
                 }
             }
         }


### PR DESCRIPTION
## What?

Closes #17

Ensure we remove `additionalProperties` from JSON response schemas

## Why?

If using the AI Client to make requests and you set a JSON response schema, OpenAI requires the `additionalProperties` key but Google will throw an error if this exists. We already remove that key from function declarations but we also need to remove it from JSON schemas

## How?

- Ensure the response schema is passed through the existing `removeAdditionalPropertiesKey` method
- Update that method to process the `items` key, both top-level and nested

### Use of AI Tools

Used Cursor running GPT-5.3 Codex to initially diagnose the problem (was reported on the WordPress AI plugin). Took the suggested fix, tested that and cleaned it up

## Testing Instructions

Hard to test with this package alone, recommend testing with the [AI plugin](https://github.com/WordPress/ai):

1. Install the AI plugin
2. Set the Google Provider up
3. Turn on the Review Notes Experiment
4. Trigger that on a post
5. Ensure it works correctly and no errors are shown in the console
