### PR TITLE
Fix: wrap bytesBase64Encoded as data URI to avoid file_exists() PHP warning spam

### DIFF
--- a/src/Models/GoogleImageGenerationModel.php
+++ b/src/Models/GoogleImageGenerationModel.php
@@ -337,7 +337,7 @@ class GoogleImageGenerationModel extends AbstractApiBasedModel implements ImageG
         if (isset($predictionData['url']) && is_string($predictionData['url'])) {
             $imageFile = new File($predictionData['url'], $mimeType);
         } elseif (isset($predictionData['bytesBase64Encoded']) && is_string($predictionData['bytesBase64Encoded'])) {
-            $imageFile = new File($predictionData['bytesBase64Encoded'], $mimeType);
+            $imageFile = new File('data:' . $mimeType . ';base64,' . $predictionData['bytesBase64Encoded'], $mimeType);
         } else {
             throw ResponseException::fromInvalidData(
                 $this->providerMetadata()->getName(),


### PR DESCRIPTION
## Problem

When Google AI returns an image via `bytesBase64Encoded`, `parseResponsePredictionToCandidate()` passes the raw base64 string directly to `new File(...)`:

```php
$imageFile = new File($predictionData['bytesBase64Encoded'], $mimeType);
```

The `File` DTO in `php-ai-client` tries to detect the input type in this order:
1. URL check → skip
2. Data URI check → skip
3. **`file_exists($file)` called** → ⚠️ PHP warning
4. Plain base64 regex → matches correctly

Base64-encoded JPEG data starts with `/9j/` (the base64 representation of the JPEG magic bytes `FF D8 FF`), which PHP interprets as an absolute file path. Since the string is typically **750 KB – 1 MB**, PHP emits:

```
PHP Warning: file_exists(): File name is longer than the maximum allowed path length on this platform (4096): /9j/4AAQSkZJRgABAQEBLAEsAAD/...
```

Because PHP embeds the full argument in the warning message, **each image generation call adds ~1 MB to the PHP error log**. In production this produced a 5.3 MB error log from only 6–8 calls.

## Fix

Wrap the base64 payload as a proper data URI before passing it to `File`:

```php
$imageFile = new File('data:' . $mimeType . ';base64,' . $predictionData['bytesBase64Encoded'], $mimeType);
```

The `File` DTO matches the data URI branch first, bypassing `file_exists()` entirely. The stored `base64Data` value is identical to before (the DTO strips the `data:...;base64,` prefix).

## Related

A complementary fix has been proposed in the core library to guard `file_exists()` with a path-length check: WordPress/php-ai-client#258. This PR is independent and fixes the issue at the source regardless of which library version is installed.

## Test plan

- [ ] Generate an image via the Imagen or Gemini multimodal endpoint
- [ ] Confirm no `file_exists()` PHP warning appears in the error log
- [ ] Confirm the returned `File` object is `inline`, has the correct MIME type, and `getBase64Data()` returns the expected data