### PR TITLE
Fix: Support combining the googleSearch built-in tool with function calling

### DIFF
--- a/src/Models/GoogleTextGenerationModel.php
+++ b/src/Models/GoogleTextGenerationModel.php
@@ -211,9 +211,12 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
             $params['generationConfig'] = $generationConfig;
         }
 
+        $customOptions = $config->getCustomOptions();
+
         $tools = [];
 
         $functionDeclarations = $config->getFunctionDeclarations();
+        $hasFunctionDeclarations = is_array($functionDeclarations) && $functionDeclarations !== [];
         if (is_array($functionDeclarations)) {
             $tools[] = [
                 'functionDeclarations' => $this->prepareFunctionDeclarationsParam($functionDeclarations),
@@ -228,13 +231,26 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
 
         if ($tools) {
             $params['tools'] = $tools;
+
+            /*
+             * The Google AI API refuses to combine a built-in server-side tool (such as
+             * `googleSearch`) with function calling unless server-side tool invocations are
+             * explicitly opted into, failing the request with "Please enable
+             * tool_config.include_server_side_tool_invocations to use Built-in tools with
+             * Function calling.". With the flag set, the API echoes each server-side
+             * invocation back as `toolCall` and `toolResponse` response parts, which
+             * parseResponseCandidateMessagePart() skips since they are not actionable by the
+             * client. A `toolConfig` passed through custom options takes precedence.
+             */
+            if ($webSearch && $hasFunctionDeclarations && !isset($customOptions['toolConfig'])) {
+                $params['toolConfig'] = ['includeServerSideToolInvocations' => true];
+            }
         }
 
         /*
          * Any custom options are added to the parameters as well.
          * This allows developers to pass other options that may be more niche or not yet supported by the SDK.
          */
-        $customOptions = $config->getCustomOptions();
         foreach ($customOptions as $key => $value) {
             // Special case: Support custom values as part of `generationConfig`.
             if (str_starts_with($key, 'generationConfig.')) {
@@ -728,9 +744,18 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
      */
     protected function parseResponseCandidateMessagePart(array $partData): ?MessagePart
     {
+        /*
+         * Built-in server-side tools (such as `googleSearch`) are echoed back as `toolCall` and
+         * `toolResponse` parts when `toolConfig.includeServerSideToolInvocations` is enabled,
+         * which is required to combine them with function calling. The tool has already run on
+         * Google's side, so there is nothing for the client to act on. The grounded answer
+         * arrives in the sibling text parts, so these parts are skipped rather than failing the
+         * entire response.
+         */
         if (isset($partData['toolCall']) || isset($partData['toolResponse'])) {
             return null;
         }
+        // A part may consist of nothing but a thought signature, which has no content to parse.
         if (isset($partData['thoughtSignature']) && count($partData) === 1) {
             return null;
         }

--- a/src/Models/GoogleTextGenerationModel.php
+++ b/src/Models/GoogleTextGenerationModel.php
@@ -702,7 +702,10 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
         $parts = [];
         foreach ($messageData['parts'] as $partIndex => $messagePartData) {
             try {
-                $parts[] = $this->parseResponseCandidateMessagePart($messagePartData);
+                $part = $this->parseResponseCandidateMessagePart($messagePartData);
+                if ($part !== null) {
+                    $parts[] = $part;
+                }
             } catch (InvalidArgumentException $e) {
                 throw ResponseException::fromInvalidData(
                     $this->providerMetadata()->getName(),
@@ -721,10 +724,16 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
      * @since 1.0.0
      *
      * @param array<string, mixed> $partData The message part data from the API response.
-     * @return MessagePart The parsed message part.
+     * @return MessagePart|null The parsed message part, or null to ignore.
      */
-    protected function parseResponseCandidateMessagePart(array $partData): MessagePart
+    protected function parseResponseCandidateMessagePart(array $partData): ?MessagePart
     {
+        if (isset($partData['toolCall']) || isset($partData['toolResponse'])) {
+            return null;
+        }
+        if (isset($partData['thoughtSignature']) && count($partData) === 1) {
+            return null;
+        }
         if (isset($partData['text'])) {
             if (!is_string($partData['text'])) {
                 throw new InvalidArgumentException('Part has an invalid text shape.');


### PR DESCRIPTION
Fixes #32

## Problem

Using `WebSearch` together with `functionDeclarations` fails in two consecutive places, so the combination doesn't work at all today.

**1. The request is rejected outright**

```
Bad Request (400) - Please enable tool_config.include_server_side_tool_invocations
to use Built-in tools with Function calling.
```

Gemini refuses to mix a built-in server-side tool with function calling unless that flag is set. The connector never sets it and exposes no option for it, so the only way past this is `ModelConfig::setCustomOption('toolConfig', ['includeServerSideToolInvocations' => true])`.

**2. Once the flag is set, the response can't be parsed**

```
Unexpected Google API response: Invalid "candidates[0].content.parts[0]" key:
Part has an unexpected type.
```

With the flag enabled, Gemini echoes the server-side invocation back into `candidates[].content.parts[]` as two extra parts keyed `toolCall` and `toolResponse`:

```json
{
  "thoughtSignature": "…",
  "toolCall": {
    "toolType": "GOOGLE_SEARCH_WEB",
    "args": { "queries": ["…"] },
    "id": "utWEB6L1"
  }
}
```

```json
{
  "thoughtSignature": "…",
  "toolResponse": {
    "toolType": "GOOGLE_SEARCH_WEB",
    "response": { "search_suggestions": "<style>…</style><div class=\"container\">…</div>" },
    "id": "TnTtVb21"
  }
}
```

`parseResponseCandidateMessagePart()` handles `text`, `inlineData`, `fileData`, `functionCall` and `functionResponse`, then throws on anything else. A part may also arrive carrying nothing but a `thoughtSignature`. The generation fails even though the model returned a perfectly good grounded answer in a sibling `text` part.

## Change

**Set the flag when it is needed.** `prepareGenerateTextParams()` already knows whether both a built-in tool and function declarations are going out, so it sets `toolConfig.includeServerSideToolInvocations` itself:

```php
if ($webSearch && $hasFunctionDeclarations && !isset($customOptions['toolConfig'])) {
    $params['toolConfig'] = ['includeServerSideToolInvocations' => true];
}
```

Nothing changes for web-search-only or function-calling-only requests — the flag is only emitted for the combination that requires it. A `toolConfig` supplied through custom options takes precedence; without that check the existing *"custom option conflicts with an existing parameter"* guard would start throwing for everyone currently using the workaround above, turning a fix into a breaking change.

**Skip the parts the flag produces.** `parseResponseCandidateMessagePart()` now returns `?MessagePart` and returns `null` for `toolCall` / `toolResponse` parts and for parts consisting only of a `thoughtSignature`; `parseResponseCandidateMessage()` filters those out. The search has already run on Google's side, so there is nothing for the client to execute — the grounded answer is in the sibling text parts, and failing the whole response to reject a part that carries no client-actionable content is the wrong trade.

## Things worth a maintainer's call

**Return type change.** `parseResponseCandidateMessagePart()` is `protected`, so widening its return type to `?MessagePart` is technically visible to subclasses. Making the caller filter seemed cleaner than a sentinel value, but I'll switch approaches if you'd rather not touch the signature.

**Dropped attribution payload.** `toolResponse.response.search_suggestions` contains Google's Search suggestion chips (HTML plus the Google logo). Google's grounding terms generally require these to be displayed for attribution, so silently dropping them is a real, if separate, gap — surfacing them as grounding metadata on the result would need somewhere in the SDK to put them. This PR is deliberately the minimal fix that stops the crash; happy to open a follow-up issue for the attribution side if that's useful.

**Empty parts.** If a candidate ever contained *only* server-side tool parts, the resulting `Message` would have no parts. `Message` accepts that and the finish-reason logic still resolves correctly, so I left it rather than inventing a placeholder part.

There is no streaming code path in this connector, so nothing else needs the same handling.

## Testing

Verified against `wordpress/php-ai-client` 1.3.1 (the version bundled with WordPress 7.0), with web search and a real WordPress Abilities tool set enabled on the same prompt:

- Web search only → no `toolConfig` in the payload, unchanged behavior.
- Function calling only → no `toolConfig` in the payload, unchanged behavior.
- Both → `toolConfig.includeServerSideToolInvocations: true` is sent, the request succeeds, the `toolCall` / `toolResponse` / signature-only parts are skipped, the grounded `text` part survives, and a `functionCall` in the same turn still resolves the finish reason to `tool_calls`.
- Both, with a caller-supplied `toolConfig` custom option → the caller's value is used and no conflict exception is raised.

`composer phpstan` (level max) and `composer phpcs` are clean — the only reported error is the pre-existing `_doing_it_wrong` symbol lookup in `GoogleImageGenerationModel.php:85`, which is present on `trunk` as well.

This branch is independent of the ones for #33 and #34 and merges cleanly with both; I've been running all three together locally.

---

This patch was drafted with the help of Claude, then manually reviewed and verified against a live Gemini setup before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
