### PR TITLE
Bump WordPress tested-up-to version 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Tags: ai, google, gemini, artificial-intelligence, connector
 Requires at least: 6.9
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 1.1.0
 Requires PHP: 7.4
 License: GPL-2.0-or-later


### PR DESCRIPTION
Tested on WP 7.1 RC3 and things function as expected when paired with the AI plugin.  This PR bumps the tested-up-to version 7.1 accordingly.