### PR TITLE
Release/1.1.1

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -8,4 +8,5 @@
 /composer.lock
 /phpcs.xml.dist
 /phpstan.neon.dist
+/README.md
 /vendor

--- a/plugin.php
+++ b/plugin.php
@@ -1,17 +1,17 @@
 <?php
 
 /**
- * Plugin Name: AI Provider for Google
- * Plugin URI: https://github.com/WordPress/ai-provider-for-google
- * Description: AI Provider for Google for the WordPress AI Client.
+ * Plugin Name:       AI Provider for Google
+ * Plugin URI:        https://github.com/WordPress/ai-provider-for-google
+ * Description:       AI Provider for Google for the WordPress AI Client.
  * Requires at least: 6.9
- * Requires PHP: 7.4
- * Version: 1.1.0
- * Author: WordPress AI Team
- * Author URI: https://make.wordpress.org/ai/
- * License: GPL-2.0-or-later
- * License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
- * Text Domain: ai-provider-for-google
+ * Requires PHP:      7.4
+ * Version:           1.1.1
+ * Author:            WordPress AI Team
+ * Author URI:        https://make.wordpress.org/ai/
+ * License:           GPL-2.0-or-later
+ * License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
+ * Text Domain:       ai-provider-for-google
  *
  * @package WordPress\GoogleAiProvider
  */

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,12 @@
 === AI Provider for Google ===
-Contributors: wordpressdotorg
-Tags: ai, google, gemini, artificial-intelligence, connector
+Contributors:      wordpressdotorg
+Tags:              ai, google, gemini, artificial-intelligence, connector
 Requires at least: 6.9
-Tested up to: 7.1
-Stable tag: 1.1.0
-Requires PHP: 7.4
-License: GPL-2.0-or-later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Tested up to:      7.1
+Stable tag:        1.1.1
+Requires PHP:      7.4
+License:           GPL-2.0-or-later
+License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
 Google AI (Gemini) provider for the PHP AI Client SDK.
 

--- a/readme.txt
+++ b/readme.txt
@@ -48,6 +48,16 @@ No, this plugin requires the PHP AI Client plugin to be installed and activated.
 
 == Changelog ==
 
+= 1.1.1 - 2026-08-17 =
+
+**Changed**
+
+* Bumped WordPress tested-up-to version 7.1 ([#39](https://github.com/WordPress/ai-provider-for-google/pull/39)).
+
+**Fixed**
+
+* Prevented PHP warning and error-log spam when processing base64-encoded images returned by Google AI ([#29](https://github.com/WordPress/ai-provider-for-google/pull/29)).
+
 = 1.1.0 =
 
 * Add support for aspect ratios with Gemini (multimodal) image generation ([#13](https://github.com/WordPress/ai-provider-for-google/pull/13)).

--- a/src/Provider/GoogleProvider.php
+++ b/src/Provider/GoogleProvider.php
@@ -84,7 +84,7 @@ class GoogleProvider extends AbstractApiProvider
             'https://aistudio.google.com/app/api-keys',
             RequestAuthenticationMethod::apiKey()
         ];
-        // Provider description support was added in 1.2.0.
+        // Provider description support was added in the WordPress AI Client 1.2.0.
         if (version_compare(AiClient::VERSION, '1.2.0', '>=')) {
             // For WordPress, we should translate the description.
             if (function_exists('__')) {


### PR DESCRIPTION
This pull request is a minor release (version 1.1.1) for the Google AI Provider plugin for WordPress. It updates compatibility information, fixes a PHP warning related to base64-encoded images, and adjusts documentation and metadata to reflect the new version.

**Documentation and Compatibility Updates:**

* Updated the tested WordPress version to 7.1 in both `readme.txt` and the changelog, and bumped the stable tag and plugin version to 1.1.1 (`readme.txt`, `plugin.php`). [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R51-R60) [[3]](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96L9-R9)
* Added `README.md` to `.distignore` to exclude it from distribution builds.

**Bug Fixes:**

* Fixed a PHP warning and error-log spam when processing base64-encoded images returned by Google AI.

**Code Comments and Metadata:**

* Clarified a comment in `GoogleProvider.php` regarding provider description support and its dependency on the WordPress AI Client version.