### PR TITLE
Add WordPress Playground preview blueprint

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,42 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/options-connectors.php",
+	"preferredVersions": {
+		"php": "8.1",
+		"wp": "latest"
+	},
+	"features": {
+		"networking": true
+	},
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "ai"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "ai-provider-for-google"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php require '/wordpress/wp-load.php'; update_option( 'wpai_features_enabled', true ); update_option( 'wpai_feature_image-generation_enabled', true );"
+		}
+	]
+}


### PR DESCRIPTION
## Summary

- add a WordPress Playground blueprint under `.wordpress-org/blueprints/`
- install and activate both the AI plugin and this provider
- enable the global AI feature flag and image generation/editing
- log in automatically and open the Connectors screen
- enable Playground networking for provider requests after credentials are configured

## Validation

- Blueprint validates against the current Playground JSON schema
- Blueprint executes successfully with `@wp-playground/cli`
- verified both plugins are active in a live Playground
- verified the AI and Image Generation and Editing settings are enabled
- `composer lint`
- `composer test` (1 test, 2 assertions)

Refs #42