### PR TITLE
fix: preserve Gemini total token usage

### DIFF
--- a/src/Models/GoogleTextGenerationModel.php
+++ b/src/Models/GoogleTextGenerationModel.php
@@ -46,7 +46,8 @@ use WordPress\GoogleAiProvider\Provider\GoogleProvider;
  * @phpstan-type UsageData array{
  *     promptTokenCount?: int,
  *     candidatesTokenCount?: int,
- *     thoughtsTokenCount?: int
+ *     thoughtsTokenCount?: int,
+ *     totalTokenCount?: int
  * }
  * @phpstan-type ResponseData array{
  *     id?: string,
@@ -578,10 +579,18 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
         if (isset($responseData['usageMetadata']) && is_array($responseData['usageMetadata'])) {
             $usage = $responseData['usageMetadata'];
 
+            $promptTokenCount = $usage['promptTokenCount'] ?? 0;
+            $candidatesTokenCount = $usage['candidatesTokenCount'] ?? 0;
+            $thoughtsTokenCount = $usage['thoughtsTokenCount'] ?? 0;
+
+            // Prefer Google's authoritative total when it is available. Older API responses may omit it.
+            $totalTokenCount = $usage['totalTokenCount'] ??
+                ($promptTokenCount + $candidatesTokenCount + $thoughtsTokenCount);
+
             $tokenUsage = new TokenUsage(
-                $usage['promptTokenCount'] ?? 0,
-                $usage['candidatesTokenCount'] ?? 0,
-                ($usage['candidatesTokenCount'] ?? 0) + ($usage['thoughtsTokenCount'] ?? 0)
+                $promptTokenCount,
+                $candidatesTokenCount,
+                $totalTokenCount
             );
         } else {
             $tokenUsage = new TokenUsage(0, 0, 0);

--- a/tests/Models/GoogleTextGenerationModelTest.php
+++ b/tests/Models/GoogleTextGenerationModelTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\GoogleAiProvider\Tests\Models;
+
+use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\GoogleAiProvider\Models\GoogleTextGenerationModel;
+
+/**
+ * Tests for the Google text generation model.
+ *
+ * @since n.e.x.t
+ */
+class GoogleTextGenerationModelTest extends TestCase
+{
+    /**
+     * Tests that Google's total token count is preserved when supplied.
+     *
+     * @since n.e.x.t
+     */
+    public function testTokenUsageUsesGoogleTotalTokenCount(): void
+    {
+        $result = $this->parseResponse([
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [['text' => 'The answer.']],
+                    ],
+                    'finishReason' => 'STOP',
+                ],
+            ],
+            'usageMetadata' => [
+                'promptTokenCount' => 26,
+                'candidatesTokenCount' => 11,
+                'thoughtsTokenCount' => 0,
+                'totalTokenCount' => 37,
+            ],
+        ]);
+
+        $tokenUsage = $result->getTokenUsage();
+
+        $this->assertSame(26, $tokenUsage->getPromptTokens());
+        $this->assertSame(11, $tokenUsage->getCompletionTokens());
+        $this->assertSame(37, $tokenUsage->getTotalTokens());
+    }
+
+    /**
+     * Tests the backward-compatible total-token fallback for older responses.
+     *
+     * @since n.e.x.t
+     */
+    public function testTokenUsageFallsBackWhenGoogleTotalTokenCountIsMissing(): void
+    {
+        $result = $this->parseResponse([
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [['text' => 'The answer.']],
+                    ],
+                    'finishReason' => 'STOP',
+                ],
+            ],
+            'usageMetadata' => [
+                'promptTokenCount' => 26,
+                'candidatesTokenCount' => 11,
+                'thoughtsTokenCount' => 3,
+            ],
+        ]);
+
+        $this->assertSame(40, $result->getTokenUsage()->getTotalTokens());
+    }
+
+    /**
+     * Parses a response through the model's protected response parser.
+     *
+     * @param array<string, mixed> $data Response data.
+     * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult Parsed result.
+     */
+    private function parseResponse(array $data): \WordPress\AiClient\Results\DTO\GenerativeAiResult
+    {
+        $model = new class (
+            new ModelMetadata('gemini-test', 'Gemini test', [CapabilityEnum::textGeneration()], []),
+            new ProviderMetadata('google', 'Google', ProviderTypeEnum::cloud())
+        ) extends GoogleTextGenerationModel {
+            /**
+             * Parses an HTTP response.
+             *
+             * @param Response $response HTTP response.
+             * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult Parsed result.
+             */
+            public function parseResponse(Response $response): \WordPress\AiClient\Results\DTO\GenerativeAiResult
+            {
+                return $this->parseResponseToGenerativeAiResult($response);
+            }
+        };
+
+        return $model->parseResponse(new Response(200, [], json_encode($data, JSON_THROW_ON_ERROR)));
+    }
+}


### PR DESCRIPTION
## Summary

- use Google's authoritative `totalTokenCount` when parsing Gemini usage metadata
- retain a backward-compatible fallback for older responses that omit the field
- add regression coverage for both the authoritative value and the fallback

The previous implementation computed the total from completion and thought tokens only, so prompt tokens were silently omitted from usage reporting.

## Testing

- `composer test`
- `composer lint`
- `git diff --check`

Fixes #22