### PR TITLE
Use parametersJsonSchema and preserve Gemini call IDs

### DIFF
--- a/src/Models/GoogleTextGenerationModel.php
+++ b/src/Models/GoogleTextGenerationModel.php
@@ -390,6 +390,10 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
             $functionCallData = [
                 'name' => $functionCall->getName(),
             ];
+            $functionCallId = $functionCall->getId();
+            if ($functionCallId !== null && $functionCallId !== '') {
+                $functionCallData['id'] = $functionCallId;
+            }
             // Only include args if present; Google's API accepts omitting args for no-argument functions.
             $args = $functionCall->getArgs();
             if ($args !== null) {
@@ -418,19 +422,24 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
                     'The function_response typed message part must contain a function response.'
                 );
             }
-            return [
-                'functionResponse' => [
-                    'name' => $functionResponse->getName(),
+            $functionResponseData = [
+                'name' => $functionResponse->getName(),
 
-                    /*
-                     * The Google AI API requires function responses to be objects.
-                     * See also https://ai.google.dev/gemini-api/docs/function-calling#multi-turn-example-1
-                     */
-                    'response' => [
-                        'name' => $functionResponse->getName(),
-                        'content' => $functionResponse->getResponse(),
-                    ],
+                /*
+                 * The Google AI API requires function responses to be objects.
+                 * See also https://ai.google.dev/gemini-api/docs/function-calling#multi-turn-example-1
+                 */
+                'response' => [
+                    'name' => $functionResponse->getName(),
+                    'content' => $functionResponse->getResponse(),
                 ],
+            ];
+            $functionResponseId = $functionResponse->getId();
+            if ($functionResponseId !== null && $functionResponseId !== '') {
+                $functionResponseData['id'] = $functionResponseId;
+            }
+            return [
+                'functionResponse' => $functionResponseData,
             ];
         }
         throw new InvalidArgumentException(
@@ -821,7 +830,8 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
             if (
                 !is_array($partData['functionCall']) ||
                 !isset($partData['functionCall']['name']) ||
-                !is_string($partData['functionCall']['name'])
+                !is_string($partData['functionCall']['name']) ||
+                (isset($partData['functionCall']['id']) && !is_string($partData['functionCall']['id']))
             ) {
                 throw new InvalidArgumentException('Part has an invalid functionCall shape.');
             }
@@ -833,8 +843,11 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
             if (is_array($args) && count($args) === 0) {
                 $args = null;
             }
+            $functionCallId = isset($partData['functionCall']['id']) && is_string($partData['functionCall']['id'])
+                ? $partData['functionCall']['id']
+                : null;
             $functionCall = new FunctionCall(
-                null,
+                $functionCallId,
                 $partData['functionCall']['name'],
                 $args
             );

--- a/src/Models/GoogleTextGenerationModel.php
+++ b/src/Models/GoogleTextGenerationModel.php
@@ -523,8 +523,8 @@ class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGen
         foreach ($functionDeclarations as $functionDeclaration) {
             $data = $functionDeclaration->toArray();
             if (isset($data['parameters'])) {
-                // The Google AI API does not allow the `additionalProperties` key for function parameters.
-                $data['parameters'] = $this->removeAdditionalPropertiesKey($data['parameters']);
+                $data['parametersJsonSchema'] = $data['parameters'];
+                unset($data['parameters']);
             }
             $preparedFunctionDeclarations[] = $data;
         }

--- a/tests/Models/GoogleTextGenerationModelTest.php
+++ b/tests/Models/GoogleTextGenerationModelTest.php
@@ -12,6 +12,7 @@ use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\GoogleAiProvider\Models\GoogleTextGenerationModel;
 
 /**
@@ -21,6 +22,72 @@ use WordPress\GoogleAiProvider\Models\GoogleTextGenerationModel;
  */
 class GoogleTextGenerationModelTest extends TestCase
 {
+    /**
+     * Tests that function parameters are forwarded as standard JSON Schema.
+     *
+     * @since n.e.x.t
+     */
+    public function testFunctionParametersUseJsonSchemaField(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'value' => [
+                    'type' => ['string', 'array'],
+                    'items' => ['type' => 'integer'],
+                ],
+                'metadata' => [
+                    'type' => 'object',
+                    'additionalProperties' => true,
+                ],
+                'priorities' => [
+                    'type' => 'array',
+                    'uniqueItems' => true,
+                    'items' => [
+                        'type' => 'integer',
+                        'enum' => [1, 2],
+                    ],
+                ],
+            ],
+            'required' => ['value'],
+        ];
+        $model = new class (
+            new ModelMetadata('gemini-test', 'Gemini test', [CapabilityEnum::textGeneration()], []),
+            new ProviderMetadata('google', 'Google', ProviderTypeEnum::cloud())
+        ) extends GoogleTextGenerationModel {
+            /**
+             * Prepares function declarations for a Google request.
+             *
+             * @param list<FunctionDeclaration> $declarations Function declarations.
+             * @return list<array<string, mixed>> Prepared declarations.
+             */
+            public function prepareFunctionDeclarations(array $declarations): array
+            {
+                return $this->prepareFunctionDeclarationsParam($declarations);
+            }
+        };
+
+        $prepared = $model->prepareFunctionDeclarations([
+            new FunctionDeclaration('complex_tool', 'Accepts a complex schema.', $schema),
+            new FunctionDeclaration('parameterless_tool', 'Accepts no parameters.'),
+        ]);
+
+        $this->assertSame(
+            [
+                [
+                    'name' => 'complex_tool',
+                    'description' => 'Accepts a complex schema.',
+                    'parametersJsonSchema' => $schema,
+                ],
+                [
+                    'name' => 'parameterless_tool',
+                    'description' => 'Accepts no parameters.',
+                ],
+            ],
+            $prepared
+        );
+    }
+
     /**
      * Tests that Google's total token count is preserved when supplied.
      *

--- a/tests/Models/GoogleTextGenerationModelTest.php
+++ b/tests/Models/GoogleTextGenerationModelTest.php
@@ -12,7 +12,9 @@ use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
 use WordPress\GoogleAiProvider\Models\GoogleTextGenerationModel;
 
 /**
@@ -208,6 +210,121 @@ class GoogleTextGenerationModelTest extends TestCase
                 'thoughtSignature' => 'sig-123',
             ],
             $model->preparePart($part)
+        );
+    }
+
+    /**
+     * Tests that Gemini function call IDs survive the response and request round trip.
+     *
+     * @since n.e.x.t
+     */
+    public function testFunctionCallIdRoundTrip(): void
+    {
+        $model = new class (
+            new ModelMetadata('gemini-test', 'Gemini test', [CapabilityEnum::textGeneration()], []),
+            new ProviderMetadata('google', 'Google', ProviderTypeEnum::cloud())
+        ) extends GoogleTextGenerationModel {
+            /**
+             * Parses an HTTP response.
+             *
+             * @param Response $response HTTP response.
+             * @return GenerativeAiResult Parsed result.
+             */
+            public function parseResponse(Response $response): GenerativeAiResult
+            {
+                return $this->parseResponseToGenerativeAiResult($response);
+            }
+
+            /**
+             * Prepares a message part for a Google request.
+             *
+             * @param MessagePart $part Message part.
+             * @return array<string, mixed> Prepared part data.
+             */
+            public function preparePart(MessagePart $part): array
+            {
+                return $this->getMessagePartData($part) ?? [];
+            }
+        };
+        $result = $model->parseResponse(new Response(200, [], json_encode([
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [
+                            [
+                                'functionCall' => [
+                                    'name' => 'lookup_post',
+                                    'args' => ['id' => 42],
+                                    'id' => 'call_123',
+                                ],
+                                'thoughtSignature' => 'sig-456',
+                            ],
+                        ],
+                    ],
+                    'finishReason' => 'STOP',
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR)));
+
+        $part = $result->getCandidates()[0]->getMessage()->getParts()[0];
+        $functionCall = $part->getFunctionCall();
+
+        $this->assertNotNull($functionCall);
+        $this->assertSame('call_123', $functionCall->getId());
+        $this->assertSame(
+            [
+                'functionCall' => [
+                    'name' => 'lookup_post',
+                    'id' => 'call_123',
+                    'args' => ['id' => 42],
+                ],
+                'thoughtSignature' => 'sig-456',
+            ],
+            $model->preparePart($part)
+        );
+        $this->assertSame(
+            [
+                'functionResponse' => [
+                    'name' => 'lookup_post',
+                    'response' => [
+                        'name' => 'lookup_post',
+                        'content' => ['title' => 'Hello world'],
+                    ],
+                    'id' => 'call_123',
+                ],
+            ],
+            $model->preparePart(
+                new MessagePart(
+                    new FunctionResponse('call_123', 'lookup_post', ['title' => 'Hello world'])
+                )
+            )
+        );
+        $this->assertSame(
+            [
+                'functionCall' => [
+                    'name' => 'lookup_post',
+                    'args' => ['id' => 42],
+                ],
+            ],
+            $model->preparePart(
+                new MessagePart(new FunctionCall('', 'lookup_post', ['id' => 42]))
+            )
+        );
+        $this->assertSame(
+            [
+                'functionResponse' => [
+                    'name' => 'lookup_post',
+                    'response' => [
+                        'name' => 'lookup_post',
+                        'content' => ['title' => 'Hello world'],
+                    ],
+                ],
+            ],
+            $model->preparePart(
+                new MessagePart(
+                    new FunctionResponse('', 'lookup_post', ['title' => 'Hello world'])
+                )
+            )
         );
     }
 


### PR DESCRIPTION
## Summary

- Send function input schemas through the Google `parametersJsonSchema` field.
- Preserve standard JSON Schema keywords instead of removing unsupported keys from the legacy `parameters` field.
- Preserve Gemini function-call IDs through response parsing and continuation requests.
- Omit empty internal IDs for older Gemini generations that do not return IDs.
- Cover complex and parameterless declarations plus identified and idless function-call round trips.

This is a simpler alternative to #35.

## Why

Gemini 3 returns a unique `functionCall.id`, and current GenerateContent guidance requires the matching `functionResponse.id`. The provider previously discarded that ID while parsing. Downstream history validation then treated the completed call and response as mismatched and removed them, causing repeated tool calls. Gemini 2.5 can still omit IDs, so empty compatibility sentinels remain omitted from Google request payloads.

## Verification

- PHPUnit: 6 tests, 18 assertions
- PHPCS: changed model and test targets passed
- PHPStan: all 9 source files passed at max level
- PHP syntax checks passed
- `git diff --check`
- Live Gemini 3.8 Flash compositional workflow completed `list-posts` then `get-post` in 3 iterations with matching unique call/response IDs and no repeats.
- Live Gemini 2.5 Flash completed the same two-step workflow in 3 iterations with idless compatibility pairing and no repeats.
- Live requests with the General-agent toolset continued to use `parametersJsonSchema` without legacy `parameters`.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.28 with gpt-5.6-sol spent 2d and 3,505,298 tokens on this with the user in an interactive session.